### PR TITLE
Invite email url, assigned to and decline activity fix

### DIFF
--- a/CRM/Pcpteams/Constant.php
+++ b/CRM/Pcpteams/Constant.php
@@ -25,10 +25,13 @@
           C_AT_GROUP_JOIN         = 'PCP Group Join',           //  Activity Type - Group Join
           C_AT_TRIBUTE_JOIN       = 'PCP Tribute Join',         //  Activity Type - Tribute Join
           C_AT_PCP_CREATED        = 'PCP Created',              //  Activity Type - pcp created
-          C_AT_REQ_MADE           = 'PCP Team Request Made',
-          C_AT_REQ_AUTHORISED     = 'PCP Team Request Authorised',
-          C_AT_REQ_DECLINED       = 'PCP Team Request Declined',
-          C_AT_INVITATION_ACCEPTED= 'PCP Team Invitation Accepted',
+          C_AT_REQ_MADE           = 'PCP Join Team Request Made',
+          C_AT_REQ_AUTHORISED     = 'PCP Member Join Team Request Authorised',
+          C_AT_REQ_DECLINED       = 'PCP  Member Join Team Request Rejected',
+          C_AT_INVITATION_JOIN_TEAM_ADMIN       = 'PCP Email invitation to Join Team (from Team Admin)',
+          C_AT_INVITATION_JOIN_TEAM_MEMBER      = 'PCP Email invitation to Join Team (from Team Member)',
+          C_AT_INVITATION_ACCEPTED_PENDING_AUTH = 'PCP Team Invitation Replied and Pending',
+          C_AT_INVITATION_ACCEPTED_AND_AUTH     = 'PCP Team Invitation Reply Authorised',
           C_AT_LEAVE_TEAM         = 'PCP Member Left Team',
           C_CONTACT_SUB_TYPE      = 'Team',                     //  Contact Sub Type - Team
           C_INVITE_MAIL_LIMIT     = 5,

--- a/CRM/Pcpteams/Form/TeamConfirm.php
+++ b/CRM/Pcpteams/Form/TeamConfirm.php
@@ -97,11 +97,6 @@ class CRM_Pcpteams_Form_TeamConfirm extends CRM_Core_Form {
     $teampcpId = CRM_Pcpteams_Utils::getPcpIdByContactAndEvent($this->get('component_page_id'), $this->get('teamContactID'));
 
     if( $msgTplId && !empty($values)) {
-      // Create Team Invite activity
-      $actParams = array(
-        'assignee_contact_id'=>  $this->get('teamContactID'),
-      );
-      $activity = CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_TEAM_INVITE);
       
       // Send Invitation emails
       $pcpDetails = civicrm_api('pcpteams', 'get', array('version' => 3, 'sequential' => 1, 'pcp_id' => $this->get('page_id')));
@@ -110,7 +105,18 @@ class CRM_Pcpteams_Form_TeamConfirm extends CRM_Core_Form {
         'eventName' => $pcpDetails['values'][0]['page_title'],
         'userName'  => $userName,
         'teamName'  => $this->get('teamName'),
+        'pageURL'   => CRM_Utils_System::url('civicrm/event/register', "reset=1&id={$this->get('component_page_id')}", TRUE, NULL, FALSE, TRUE),
       );
+      // As team contact id is set in the team join post process, team contact id is not available in this form if you are coming from manage page
+      $teamContactId = $this->get('teamContactID');
+      if (empty($teamContactId)) {
+        $teamContactId = $pcpDetails['values'][0]['contact_id'];
+      }
+      // Create Team Invite activity
+      $actParams = array(
+        'assignee_contact_id'=>   $teamContactId,
+      );
+      $activity = CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_TEAM_INVITE);
       
       $result = CRM_Pcpteams_Utils::sendInviteEmail($msgTplId, $this->_contactID, $values, $teampcpId, $activity['id']);
       if ($result) {

--- a/CRM/Pcpteams/Form/TeamConfirm.php
+++ b/CRM/Pcpteams/Form/TeamConfirm.php
@@ -105,7 +105,7 @@ class CRM_Pcpteams_Form_TeamConfirm extends CRM_Core_Form {
         'eventName' => $pcpDetails['values'][0]['page_title'],
         'userName'  => $userName,
         'teamName'  => $this->get('teamName'),
-        'pageURL'   => CRM_Utils_System::url('civicrm/event/register', "reset=1&id={$this->get('component_page_id')}", TRUE, NULL, FALSE, TRUE),
+        'pageURL'   => CRM_Utils_System::url('civicrm/pcp/support', "reset=1&pageId={$this->get('component_page_id')}&component=event&tpId={$this->get('page_id')}", TRUE, NULL, FALSE, TRUE),
       );
       // As team contact id is set in the team join post process, team contact id is not available in this form if you are coming from manage page
       $teamContactId = $this->get('teamContactID');
@@ -116,7 +116,16 @@ class CRM_Pcpteams_Form_TeamConfirm extends CRM_Core_Form {
       $actParams = array(
         'assignee_contact_id'=>   $teamContactId,
       );
-      $activity = CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_TEAM_INVITE);
+      $checkAdminParams = array(
+        'version' => 3,
+        'user_id' => $this->_contactID,
+        'team_contact_id' => $teamContactId,
+      );
+      $chkTeamAdmin= civicrm_api('Pcpteams', 'checkTeamAdmin', $checkAdminParams);
+      $isTeamAdmin = $chkTeamAdmin['is_team_admin'];
+        
+      $teamInviteActivityType = $isTeamAdmin ? CRM_Pcpteams_Constant::C_AT_INVITATION_JOIN_TEAM_ADMIN : CRM_Pcpteams_Constant::C_AT_INVITATION_JOIN_TEAM_MEMBER;
+      $activity = CRM_Pcpteams_Utils::createPcpActivity($actParams, $teamInviteActivityType);
       
       $result = CRM_Pcpteams_Utils::sendInviteEmail($msgTplId, $this->_contactID, $values, $teampcpId, $activity['id']);
       if ($result) {

--- a/CRM/Pcpteams/Form/TeamInvite.php
+++ b/CRM/Pcpteams/Form/TeamInvite.php
@@ -70,9 +70,10 @@ class CRM_Pcpteams_Form_TeamInvite {
     $form->set('teamContactID', $teamId);
     // Team Join: create activity
     $actParams = array(
-      'target_contact_id' => $teamId
+      'target_contact_id' => CRM_Pcpteams_Utils::getTeamAdmin($teampcpId),
+      'assignee_contact_id' => $teamId
     );
-    CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_INVITATION_ACCEPTED);
+    CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_INVITATION_ACCEPTED_PENDING_AUTH);
     CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_REQ_MADE);
 
     if ($result) {

--- a/CRM/Pcpteams/Page/AJAX.php
+++ b/CRM/Pcpteams/Page/AJAX.php
@@ -225,7 +225,7 @@ class CRM_Pcpteams_Page_AJAX {
         'assignee_contact_id'=>  $assigneeId,
         'target_contact_id'  =>  $targetId,
       );
-      CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_REQ_AUTHORISED);
+      CRM_Pcpteams_Utils::createPcpActivity($actParams, CRM_Pcpteams_Constant::C_AT_REQ_DECLINED);
       //end
       echo 'declined';
     }else{

--- a/CRM/Pcpteams/Utils.php
+++ b/CRM/Pcpteams/Utils.php
@@ -376,21 +376,14 @@ class  CRM_Pcpteams_Utils {
         $subject = 'Team is created';
         $details = 'Team is created'.$targetName;
         break;
-      case CRM_Pcpteams_Constant::C_AT_TEAM_INVITE:
-        $isTeamAdmin = 0;
-        if (isset($params['assignee_contact_id'])) {
-          $targetName = CRM_Contact_BAO_Contact::displayName($params['assignee_contact_id']);
-          $checkAdminParams = array(
-            'version' => 3,
-            'user_id' => $params['source_contact_id'],
-            'team_contact_id' => $params['assignee_contact_id'],
-          );
-          $chkTeamAdmin= civicrm_api('Pcpteams', 'checkTeamAdmin', $checkAdminParams);
-          $isTeamAdmin = $chkTeamAdmin['is_team_admin'];
-        }
-        
-        $sourceName .= $isTeamAdmin ? ' ( Team Admin )' : ' ( Team Member )';
-        $subject = 'Invite to join team';
+      case CRM_Pcpteams_Constant::C_AT_INVITATION_JOIN_TEAM_ADMIN:
+        $sourceName .= ' ( Team Admin )' ;
+        $subject = 'Team Member Invite to Join Team';
+        $details = 'Invited to join team '.$targetName. ' by '.$sourceName;
+        break;
+      case CRM_Pcpteams_Constant::C_AT_INVITATION_JOIN_TEAM_MEMBER:
+        $sourceName .= ' ( Team Member )';
+        $subject = 'Team Member Invite to Join Team';
         $details = 'Invited to join team '.$targetName. ' by '.$sourceName;
         break;
       case CRM_Pcpteams_Constant::C_AT_GROUP_JOIN:
@@ -415,7 +408,7 @@ class  CRM_Pcpteams_Utils {
         $details = "Member join team request has declined";
         break;
       case CRM_Pcpteams_Constant::C_AT_REQ_MADE:
-        $subject = 'Sent team request';
+        $subject = 'Team Member Requires Authorisation';
         $details = "Member join team request made by".$sourceName.' to '. $targetName;
         break;
       case CRM_Pcpteams_Constant::C_AT_LEAVE_TEAM:

--- a/message_templates/msg_tpl_invite_members_to_team.tpl
+++ b/message_templates/msg_tpl_invite_members_to_team.tpl
@@ -23,6 +23,8 @@
 
   We hope you take the plunge! Love the LLR fundraising team
 </p>
+  
+<p><a href="{$pageURL}">{ts}Join fundraising Team{/ts}</a></p>
 
 </body>
 </html>

--- a/xml/CustomGroupData.xml
+++ b/xml/CustomGroupData.xml
@@ -228,8 +228,8 @@
       <option_group_name>activity_type</option_group_name>
     </OptionValue>
     <OptionValue>
-      <label>PCP Team Request Made</label>
-      <name>PCP Team Request Made</name>
+      <label>PCP Join Team Request Made</label>
+      <name>PCP Join Team Request Made</name>
       <filter>0</filter>
       <is_default>0</is_default>
       <weight>1</weight>
@@ -239,8 +239,8 @@
       <option_group_name>activity_type</option_group_name>
     </OptionValue>
     <OptionValue>
-      <label>PCP Team Request Authorised</label>
-      <name>PCP Team Request Authorised</name>
+      <label>PCP Member Join Team Request Authorised</label>
+      <name>PCP Member Join Team Request Authorised</name>
       <filter>0</filter>
       <is_default>0</is_default>
       <weight>1</weight>
@@ -250,8 +250,8 @@
       <option_group_name>activity_type</option_group_name>
     </OptionValue>
     <OptionValue>
-      <label>PCP Team Request Declined</label>
-      <name>PCP Team Request Declined</name>
+      <label>PCP Member Join Team Request Rejected</label>
+      <name>PCP Member Join Team Request Rejected</name>
       <filter>0</filter>
       <is_default>0</is_default>
       <weight>1</weight>
@@ -272,8 +272,8 @@
       <option_group_name>activity_type</option_group_name>
     </OptionValue>
     <OptionValue>
-      <label>PCP Team Invitation Accepted</label>
-      <name>PCP Team Invitation Accepted</name>
+      <label>PCP Team Invitation Reply Authorised</label>
+      <name>PCP Team Invitation Reply Authorised</name>
       <filter>0</filter>
       <is_default>0</is_default>
       <weight>1</weight>
@@ -329,6 +329,39 @@
     <OptionValue>
       <label>PCP Tribute Join</label>
       <name>PCP Tribute Join</name>
+      <filter>0</filter>
+      <is_default>0</is_default>
+      <weight>5</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>0</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>activity_type</option_group_name>
+    </OptionValue>
+    <OptionValue>
+      <label>PCP Email invitation to Join Team (from Team Admin)</label>
+      <name>PCP Email invitation to Join Team (from Team Admin)</name>
+      <filter>0</filter>
+      <is_default>0</is_default>
+      <weight>5</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>0</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>activity_type</option_group_name>
+    </OptionValue>
+    <OptionValue>
+      <label>PCP Email invitation to Join Team (from Team Member)</label>
+      <name>PCP Email invitation to Join Team (from Team Member)</name>
+      <filter>0</filter>
+      <is_default>0</is_default>
+      <weight>5</weight>
+      <is_optgroup>0</is_optgroup>
+      <is_reserved>0</is_reserved>
+      <is_active>1</is_active>
+      <option_group_name>activity_type</option_group_name>
+    </OptionValue>
+    <OptionValue>
+      <label>PCP Team Invitation Replied and Pending</label>
+      <name>PCP Team Invitation Replied and Pending</name>
       <filter>0</filter>
       <is_default>0</is_default>
       <weight>5</weight>


### PR DESCRIPTION
1. 'pageURl' implemented for 'msg_invite template' in the invitation email

2. Assigned to fix in activities

3. Corrected activity type for declined member